### PR TITLE
Exempt completed pods from checks.

### DIFF
--- a/chart/k8s-cluster-update-controller/values.yaml
+++ b/chart/k8s-cluster-update-controller/values.yaml
@@ -2,13 +2,14 @@ replicas: 1
 
 image:
   repository: lannparty/k8s-cluster-update-controller
-  tag: "1.1"
+  tag: "v1.2"
   pullPolicy: Always
 
 # How long to wait in seconds between each pod eviction.
 evictionWaitTime: 5
 
 # List of namespaces to check for stability after every cordon and eviction. Comma delimited list, no spaces. Ex: "ilmn-system,kube-system"
+# If empty, will check ALL namespaces.
 vitalNamespaces: "ilmn-system,kube-system"
 
 # How long to wait between each vitalNamespaces validation.

--- a/pkg/kubecmd/kubecmd.go
+++ b/pkg/kubecmd/kubecmd.go
@@ -94,11 +94,11 @@ func EvictPodsOnCordonedNodes(clientset kubernetes.Interface, cordonedNodeName s
 
 func ValidateNamespaces(clientset kubernetes.Interface, namespaces []string) bool {
 	for _, j := range namespaces {
-		optionsModifier := metav1.ListOptions{FieldSelector: "status.phase!=Running"}
+		optionsModifier := metav1.ListOptions{FieldSelector: "status.phase!=Running,status.Phase!=Succeeded"}
 		podList, _ := clientset.CoreV1().Pods(j).List(optionsModifier)
 		if len(podList.Items) != 0 {
 			for _, j := range podList.Items {
-				fmt.Println(j.Name)
+                                fmt.Println(j.Name)
 			}
 			return false
 		}


### PR DESCRIPTION
This can be validated with: 
```
kubectl get pods --field-selector 'status.phase!=Succeeded,status.phase!=Running' --all-namespaces
```