### PR TITLE
Counter and retry threshold for failed evictions. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # Popular IDE extension files
 .vscode/
+
+# Vim swap
+*.swp

--- a/chart/k8s-cluster-update-controller/Chart.yaml
+++ b/chart/k8s-cluster-update-controller/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.2
+appVersion: 1.3
 description: Deploy the k8s-cluster-update-controller
 name: k8s-cluster-update-controller
-version: 1.2
+version: 1.3

--- a/chart/k8s-cluster-update-controller/templates/deployment.yaml
+++ b/chart/k8s-cluster-update-controller/templates/deployment.yaml
@@ -19,13 +19,15 @@ spec:
         env:
         - name: TARGETLABELS
           value: "{{ .Values.targetLabels}}"
-        - name: EVICTIONWAITTIME
-          value: "{{ .Values.evictionWaitTime }}"
         - name: VALIDATEWAITTIME
           value: "{{ .Values.validateWaitTime }}"
         - name: VITALNAMESPACES
           value: "{{ .Values.vitalNamespaces }}"
         - name: EXEMPTPODLABELS
-          value: "{{ .Values.exemptPodLabels }}"
+          value: "{{ .Values.eviction.exemptPodLabels }}"
         - name: EVICTIONSTRATEGY
-          value: "{{ .Values.evictionStrategy }}"
+          value: "{{ .Values.eviction.strategy }}"
+        - name: RETRYTHRESHOLD
+          value: "{{ .Values.eviction.threshold }}"
+        - name: EVICTIONWAITTIME
+          value: "{{ .Values.eviction.wait }}"

--- a/chart/k8s-cluster-update-controller/values.yaml
+++ b/chart/k8s-cluster-update-controller/values.yaml
@@ -2,15 +2,12 @@ replicas: 1
 
 image:
   repository: lannparty/k8s-cluster-update-controller
-  tag: "v1.2"
+  tag: "v1.3"
   pullPolicy: Always
-
-# How long to wait in seconds between each pod eviction.
-evictionWaitTime: 5
 
 # List of namespaces to check for stability after every cordon and eviction. Comma delimited list, no spaces. Ex: "ilmn-system,kube-system"
 # If empty, will check ALL namespaces.
-vitalNamespaces: "ilmn-system,kube-system"
+vitalNamespaces: "kube-system"
 
 # How long to wait between each vitalNamespaces validation.
 validateWaitTime: 300
@@ -21,8 +18,13 @@ validateWaitTime: 300
 # Multiple labels are comma separated.
 targetLabels: "kubernetes.io/role!=master,image!=nonexistent"
 
-# Pod labels to exempt from evictions. Comma delimited list, no spaces. Ex: "app:nginx,app:backend"
-exemptPodLabels: "k8s-app:kube-proxy"
 
-# What to do if pdb is encountered during eviction. Skip will move on to the next pod, retry will loop indefinitely.
-evictionStrategy: retry
+# What to do if pdb is encountered during eviction. , retry will loop indefinitely.
+eviction:
+  # 'retry' will retry every ${wait} seconds until ${threshold} is reached. 'skip' will move on. Empty threshold will retry infinitely.
+  strategy: retry
+  threshold: 30
+  wait: 5
+
+  # Pod labels to exempt from evictions. Comma delimited list, no spaces. Ex: "app:nginx,app:backend"
+  exemptPodLabels: "k8s-app:kube-proxy,app:k8s-cluster-update-controller"


### PR DESCRIPTION
Also refactor skip mode to be at node level.

Tested locally on minikube.
```
0817 20:15:25.988972       6 controller.go:177] Eviction of pods on minikube-m05 failed with error Cannot evict pod as it would violate the pod's disruption budget., eviction strategy: retry, retry threshold: 30, retry count: 27
Evicting lannparty2-78fbb47b5c-xnhhv
E0817 20:15:26.009562       6 kubecmd.go:80] Eviction of pod lannparty2-78fbb47b5c-xnhhv on node minikube-m05 failed with error Cannot evict pod as it would violate the pod's disruption budget.
Skipping pod kindnet-dxdc4 because it's a Daemonset.
Skipping pod kube-proxy-ttgzh because it's a Daemonset.
```
After threshold of 30 is reached, the controller skips on to next node.

Skip mode will skip always.